### PR TITLE
updated weight add instructions on blog and weights of existing blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Edit the `index.md` file and update the fields:
 - **Title**: Add your blog title.
 - **Description**: Provide a brief summary of your blog.
 - **Image**: Include an image. Use either a relevant image or the default `dcj.jpeg` located at `images/dcj.jpeg`.
+- **Weight**: Keep the weight as value 100 for your blogs, the redordering will be based on the date
 
 For **Markdown tips**, check out the [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet/).
 

--- a/content/en/blog/cncf-contribution-guide/index.md
+++ b/content/en/blog/cncf-contribution-guide/index.md
@@ -6,7 +6,7 @@ excerpt: "Learn how to contribute to open source projects and embrace the DevOps
 date: 2024-09-30T09:56:11+05:30  
 lastmod: 2024-09-30T09:56:11+05:30  
 draft: false  
-weight: 45  
+weight: 100  
 images: [cover.png]  
 categories: [Open Source]  
 tags: ["Contribution", "Open Source", "Community"]  

--- a/content/en/blog/devops/index.md
+++ b/content/en/blog/devops/index.md
@@ -5,7 +5,7 @@ excerpt: "The DevOps Methodology Merges Software Development and Operations"
 date: 2024-09-15T05:00:00+04:00
 lastmod: 2024-09-15T05:00:00+04:00
 draft: false
-weight: 45
+weight: 100
 images: [devops.jpeg]
 categories: ["DevOps"]
 tags: ["CI/CD", "performance", "DevOps"]

--- a/content/en/blog/git-branching/index.md
+++ b/content/en/blog/git-branching/index.md
@@ -5,7 +5,7 @@ excerpt: "Explore various strategies and best practices for managing branches in
 date: 2024-10-05T08:58:29-04:00
 lastmod: 2024-10-05T08:58:29-04:00
 draft: false
-weight: 44
+weight: 100
 images: [branch-img.png]
 categories: ["Devops", "Git"]
 tags: ["DevOps", "Git", "Collaborative Development"]

--- a/content/en/blog/kube-autoscaler/index.md
+++ b/content/en/blog/kube-autoscaler/index.md
@@ -2,10 +2,10 @@
 title: "Autoscaling Pods in Kubernetes: A Comprehensive Guide"
 description: ""
 excerpt: "Autoscaling Pods in Kubernetes: A Comprehensive Guide"
-date: 2024-09-15T04:19:42+04:00
-lastmod: 2024-09-15T04:19:42+04:00
+date: 2024-09-16T04:19:42+04:00
+lastmod: 2024-09-16T04:19:42+04:00
 draft: false
-weight: 60
+weight: 100
 images: [autoscaling.jpg]
 categories: ["Kubernetes"]
 tags: ["Kubernetes", "scalability", "performance"]

--- a/content/en/blog/say-hello-to-devopscloudjunction/index.md
+++ b/content/en/blog/say-hello-to-devopscloudjunction/index.md
@@ -5,7 +5,7 @@ excerpt: "Introducing DevOpsCloudJunction, Empowering Innovation Through DevOps,
 date: 2024-09-15T00:00:00+04:00
 lastmod: 2024-09-15T00:00:00+04:00
 draft: false
-weight: 90
+weight: 100
 images: [hello.jpg]
 categories: ["News"]
 tags: ["cloud", "devops", "devopscloud", "kubernetes"]


### PR DESCRIPTION
## Summary

the weight field in index.md of blog has to be static value. use 100 for the same. the blog reordering will be based on the date of blog addtion

## Basic example

example:

date: 2024-09-15T00:00:00+04:00 ---> ordered as per date, newest blogs to come on top as per this 
lastmod: 2024-09-15T00:00:00+04:00
draft: false
weight: 100 ----> keep it '100' always
images: [hello.jpg]

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
