### PR TITLE
Add DCO Sign-off Check in CI Workflow

### DIFF
--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -1,0 +1,15 @@
+name: DCO
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  check_dco:
+    runs-on: ubuntu-latest
+    name: Check DCO
+    steps:
+      - name: Run dco-check
+        uses: christophebedard/dco-check@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- This PR introduces a DCO (Developer Certificate of Origin) sign-off check in our CI workflow to ensure that all commits are compliant with our project’s [Contributing Guide](https://github.com/DevOpsCloudJunction/website/blob/main/CONTRIBUTING.md#contributor-compliance-with-developer-certificate-of-origin-dco). The DCO check verifies that each commit includes a Signed-off-by line, indicating the author’s compliance with the DCO. This is a common best practice in open-source projects to clarify authorship and responsibility.

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
