### PR TITLE
feat: Put the logo instead of website name

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -118,4 +118,7 @@ rel  = "sitemap"
   [services.googleAnalytics]
     ID = 'G-J1ZLS1SH1C'
 [params]
-disqusShortname = "devopscloudjunction-1"
+  siteLogo = true
+  siteLogoLight = "favicon.svg"
+  siteLogoDark = "favicon.svg"
+  siteLogoWidth = 78


### PR DESCRIPTION
## Summary
- Previously we have "DevopsCloudJunction" at the top right. Now, i replaced with logo. 

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
